### PR TITLE
feat: Implement add task modal and functionality

### DIFF
--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -3,8 +3,12 @@
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { Plus } from 'lucide-react';
+import { useState } from 'react'; // Added
 import { KanbanColumn as KanbanColumnInterface } from '../interfaces/kanban-column.interface';
 import TaskCard from './TaskCard';
+import TaskFormModal from './TaskFormModal'; // Added
+import { useKanban } from '../hooks/use-kanban.hook'; // Added
+import { TaskStatus } from '../types/task-status.type'; // Added
 import { getColumnColor } from '../utils/kanban.utils';
 
 type KanbanColumnProps = {
@@ -16,7 +20,23 @@ export default function KanbanColumn({ column }: KanbanColumnProps) {
     id: column.id,
   });
 
+  const { createTask } = useKanban(); // Added
+  const [isModalOpen, setIsModalOpen] = useState(false); // Added
+
   const taskIds = column.tasks.map(task => task.id);
+
+  const handleOpenModal = () => setIsModalOpen(true); // Added
+  const handleCloseModal = () => setIsModalOpen(false); // Added
+
+  const handleCreateTask = (formData: { title: string; description: string; dueDate: string; status: TaskStatus }) => { // Added
+    createTask({
+      title: formData.title,
+      description: formData.description,
+      dueDate: new Date(formData.dueDate), // Ensure dueDate is a Date object
+      status: formData.status,
+    });
+    // The useKanban hook's createTask should handle refreshing the task list
+  };
 
   return (
     <div className="flex-1 min-w-80">
@@ -31,7 +51,10 @@ export default function KanbanColumn({ column }: KanbanColumnProps) {
               {column.tasks.length}
             </span>
           </div>
-          <button className="flex items-center gap-1 text-gray-500 hover:text-gray-700 text-xs transition-colors">
+          <button
+            onClick={handleOpenModal} // Modified
+            className="flex items-center gap-1 text-gray-500 hover:text-gray-700 text-xs transition-colors"
+          >
             <Plus className="w-3 h-3" />
             Agregar tarea
           </button>
@@ -57,6 +80,13 @@ export default function KanbanColumn({ column }: KanbanColumnProps) {
           )}
         </div>
       </div>
+      {/* Modal Render */}
+      <TaskFormModal // Added
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        onSubmit={handleCreateTask}
+        initialStatus={column.id as TaskStatus} // Pass current column's ID as initial status
+      />
     </div>
   );
 } 

--- a/src/components/TaskFormModal.tsx
+++ b/src/components/TaskFormModal.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useState, FormEvent, useEffect } from 'react';
+import { TaskStatus } from '../types/task-status.type';
+
+interface TaskFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (formData: { title: string; description: string; dueDate: string, status: TaskStatus }) => void;
+  initialStatus: TaskStatus;
+}
+
+export default function TaskFormModal({ isOpen, onClose, onSubmit, initialStatus }: TaskFormModalProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [dueDate, setDueDate] = useState('');
+
+  useEffect(() => {
+    // Reset form when modal opens or initialStatus changes
+    if (isOpen) {
+      setTitle('');
+      setDescription('');
+      setDueDate('');
+    }
+  }, [isOpen, initialStatus]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!title.trim() || !dueDate) {
+      // Basic validation: title and dueDate are required
+      alert('Título y Fecha de Vencimiento son obligatorios.');
+      return;
+    }
+    onSubmit({ title, description, dueDate, status: initialStatus });
+    onClose(); // Close modal after submission
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-semibold text-gray-800">Agregar Nueva Tarea</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 transition-colors"
+            aria-label="Cerrar modal"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
+              Título <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              required
+            />
+          </div>
+
+          <div className="mb-4">
+            <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+              Descripción
+            </label>
+            <textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+            />
+          </div>
+
+          <div className="mb-6">
+            <label htmlFor="dueDate" className="block text-sm font-medium text-gray-700 mb-1">
+              Fecha de Vencimiento <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="date"
+              id="dueDate"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              required
+            />
+          </div>
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
+            >
+              Guardar Tarea
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a modal to create new tasks directly from the Kanban columns.

Key changes:
- Created `TaskFormModal.tsx`: A new component that provides a form (title, description, dueDate) for creating tasks. Styled with Tailwind CSS.
- Modified `KanbanColumn.tsx`:
    - Integrated `TaskFormModal`, managing its visibility via local state.
    - The 'Agregar tarea' button now opens this modal.
    - Uses the `useKanban` hook to call `createTask` upon form submission.
    - The new task is assigned the status of the column it's created from.
- The `useKanban` hook's existing `createTask` function handles adding the task to the in-memory `taskService` and refreshing the board, so no changes were needed there.
- Dates are handled as `Date` objects, with `dueDate` being initialized from the date input string.

This allows you to dynamically add tasks to any column in the Kanban board.