### PR TITLE
Add modal form to create tasks

### DIFF
--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+
+export type AddTaskFormData = {
+  title: string;
+  description: string;
+  dueDate: string;
+};
+
+type AddTaskModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: AddTaskFormData) => void;
+};
+
+export default function AddTaskModal({ isOpen, onClose, onSubmit }: AddTaskModalProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [dueDate, setDueDate] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ title, description, dueDate });
+    setTitle('');
+    setDescription('');
+    setDueDate('');
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md">
+        <h3 className="text-lg font-medium mb-4">Agregar tarea</h3>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="text"
+            required
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder="Título"
+            className="w-full border rounded px-3 py-2 text-sm"
+          />
+          <textarea
+            required
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Descripción"
+            className="w-full border rounded px-3 py-2 text-sm"
+            rows={3}
+          />
+          <input
+            type="date"
+            required
+            value={dueDate}
+            onChange={e => setDueDate(e.target.value)}
+            className="w-full border rounded px-3 py-2 text-sm"
+          />
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1 text-sm rounded border border-gray-300 hover:bg-gray-100"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="px-3 py-1 text-sm rounded bg-blue-600 text-white hover:bg-blue-700"
+            >
+              Agregar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -19,7 +19,7 @@ import KanbanColumn from './KanbanColumn';
 import TaskCard from './TaskCard';
 
 export default function KanbanBoard() {
-  const { columns, loading, moveTask } = useKanban();
+  const { columns, loading, moveTask, createTask } = useKanban();
   const [activeTask, setActiveTask] = useState<Task | null>(null);
 
   const sensors = useSensors(
@@ -118,7 +118,11 @@ export default function KanbanBoard() {
           <div className="flex gap-6 h-full overflow-x-auto">
             <SortableContext items={columns.map(col => col.id)}>
               {columns.map(column => (
-                <KanbanColumn key={column.id} column={column} />
+                <KanbanColumn
+                  key={column.id}
+                  column={column}
+                  onAddTask={createTask}
+                />
               ))}
             </SortableContext>
           </div>

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -3,24 +3,40 @@
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { Plus } from 'lucide-react';
+import { useState } from 'react';
 import { KanbanColumn as KanbanColumnInterface } from '../interfaces/kanban-column.interface';
+import { Task } from '../interfaces/task.interface';
 import TaskCard from './TaskCard';
+import AddTaskModal, { AddTaskFormData } from './AddTaskModal';
 import { getColumnColor } from '../utils/kanban.utils';
 
 type KanbanColumnProps = {
   column: KanbanColumnInterface;
+  onAddTask: (task: Omit<Task, 'id' | 'createdAt' | 'updatedAt'>) => void;
 };
 
-export default function KanbanColumn({ column }: KanbanColumnProps) {
+export default function KanbanColumn({ column, onAddTask }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: column.id,
   });
 
+  const [open, setOpen] = useState(false);
+
   const taskIds = column.tasks.map(task => task.id);
 
+  const handleAddTask = (data: AddTaskFormData) => {
+    onAddTask({
+      title: data.title,
+      description: data.description,
+      dueDate: new Date(data.dueDate),
+      status: column.id,
+    });
+  };
+
   return (
-    <div className="flex-1 min-w-80">
-      <div className={`rounded-lg border-2 ${getColumnColor(column.id)} h-full flex flex-col`}>
+    <>
+      <div className="flex-1 min-w-80">
+        <div className={`rounded-lg border-2 ${getColumnColor(column.id)} h-full flex flex-col`}>
         {/* Header */}
         <div className="p-4 border-b border-gray-200">
           <div className="flex items-center justify-between mb-2">
@@ -31,7 +47,10 @@ export default function KanbanColumn({ column }: KanbanColumnProps) {
               {column.tasks.length}
             </span>
           </div>
-          <button className="flex items-center gap-1 text-gray-500 hover:text-gray-700 text-xs transition-colors">
+          <button
+            onClick={() => setOpen(true)}
+            className="flex items-center gap-1 text-gray-500 hover:text-gray-700 text-xs transition-colors"
+          >
             <Plus className="w-3 h-3" />
             Agregar tarea
           </button>
@@ -56,7 +75,13 @@ export default function KanbanColumn({ column }: KanbanColumnProps) {
             </div>
           )}
         </div>
+        </div>
       </div>
-    </div>
+      <AddTaskModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onSubmit={handleAddTask}
+      />
+    </>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- implement `AddTaskModal` component for capturing new task data
- integrate modal into `KanbanColumn` and call provided add task handler
- pass add task handler from `KanbanBoard`

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `npx tsc --noEmit` *(fails: cannot find module 'next' or its types)*

------
https://chatgpt.com/codex/tasks/task_e_684221524764832eb6003d729799b0fc